### PR TITLE
Add references to glossary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Please report security vulnerabilities directly to [@chartgerink](mailto:chris@l
 
 ### Where to start?
 
-Our work is organized on [GitHub Issues](https://github.com/hypergraph-xyz/cli/issues). Our [Roadmap (see issues in the CLI column marked with an ❌)](https://github.com/hypergraph-xyz/desktop/wiki/Roadmap) contains issues that we are planning on working on further down the line. If you're enthusiastic about one of these features, come and discuss it with us on [Slack](https://libscie.slack.com/) ([invite link](https://join.slack.com/t/libscie/shared_invite/zt-9l0ig1x1-Sxjun7D6056cOUQ2Ai_Bkw)).
+Our work is organized on [GitHub Issues](https://github.com/hypergraph-xyz/cli/issues). Our [Roadmap (see issues in the CLI column marked with an ❌)](https://github.com/hypergraph-xyz/desktop/wiki/Roadmap) contains issues that we are planning on working on further down the line. If you're enthusiastic about one of these features, come and discuss it with us on [Slack](https://libscie.slack.com/) ([invite link](https://join.slack.com/t/libscie/shared_invite/zt-9l0ig1x1-Sxjun7D6056cOUQ2Ai_Bkw)). You might also find the [Hypergraph glossary](https://www.notion.so/Glossary-d4bdf18fb4624c049c7a2663559ef5ad) useful as it explains most of the product-specific terminology we use.
 
 Technical improvements, bug fixes, documentation and other non-feature work is also totally welcome.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ omit an action, input, or argument(s) (if relevant).
 Help is provided under `hypergraph --help` and the maintainers will do
 their best to answer your questions in the issues.
 
+## How to release
+
+1. `npm run release` will guide you through the node module process and create a GitHub release
+1. Write release notes and publish the GitHub release
+1. Tell your Hypergraph friends about it
+
 ## Glossary
 
 If you're interested in learning more about our terminology, the [Hypergraph glossary](https://www.notion.so/Glossary-d4bdf18fb4624c049c7a2663559ef5ad) explains many of the terms we use across Hypergraph products and documentation.

--- a/README.md
+++ b/README.md
@@ -109,11 +109,9 @@ omit an action, input, or argument(s) (if relevant).
 Help is provided under `hypergraph --help` and the maintainers will do
 their best to answer your questions in the issues.
 
-## How to release
+## Glossary
 
-1. `npm run release` will guide you through the node module process and create a GitHub release
-1. Write release notes and publish the GitHub release
-1. Tell your Hypergraph friends about it
+If you're interested in learning more about our terminology, the [Hypergraph glossary](https://www.notion.so/Glossary-d4bdf18fb4624c049c7a2663559ef5ad) explains many of the terms we use across Hypergraph products and documentation.
 
 ## Contributors ✨
 


### PR DESCRIPTION
Added references to the glossary in the readme and contributing doc.

I thought that the release instructions in the readme were no longer relevant, given that we leave that up to our maintainer(s). Let me know if that's not correct.